### PR TITLE
Correção da última modificação

### DIFF
--- a/index.hs
+++ b/index.hs
@@ -16,7 +16,7 @@ adcCidade = do
     let adcCid :: [Cidade]
         adcCid = [(cidadeNV, localizacao, [])]
     let novoMapa = loadMapa ++ adcCid
-    salvarMapa adcCid "saida.mapa"
+    salvarMapa novoMapa "saida.mapa"
 
     print novoMapa
 


### PR DESCRIPTION
Antes:
salvarMapa adcCid "saida.mapa" - errado
Para:
salvarMapa novoMapa "saida.mapa" - correto